### PR TITLE
fix query usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Available methods:
 **in a template**
 
 ```hbs
-{{#let (query 'blog' query=(hash ...)) as |blogs|}}
+{{#let (query 'blog' (hash ...)) as |blogs|}}
   {{#if blogs.isLoading}}
       ...
   {{else if blogs.isError}}
@@ -206,7 +206,7 @@ See: [First-class Component Templates](https://github.com/emberjs/rfcs/pull/779)
 import { Query } from 'ember-data-resources';
 
 <template>
-  {{#let (Query 'blog' query=(hash ...)) as |blogs|}}
+  {{#let (Query 'blog' (hash ...)) as |blogs|}}
     ...
   {{/let}}
 </template>
@@ -242,7 +242,7 @@ Available methods:
 **in a template**
 
 ```hbs
-{{#let (query-record 'blog' query=(hash ...)) as |blog|}}
+{{#let (query-record 'blog' (hash ...)) as |blog|}}
   {{#if blog.isLoading}}
       ...
   {{else if blog.isError}}
@@ -273,7 +273,7 @@ See: [First-class Component Templates](https://github.com/emberjs/rfcs/pull/779)
 import { QueryRecord } from 'ember-data-resources';
 
 <template>
-  {{#let (QueryRecord 'blog' query=(hash ...)) as |blog|}}
+  {{#let (QueryRecord 'blog' (hash ...)) as |blog|}}
     ...
   {{/let}}
 </template>


### PR DESCRIPTION
Tried using query as the README stated, but gave an error.
Checked the code and the definition is that only `options` is a named parameter. Query is part of the positionals.
https://github.com/NullVoxPopuli/ember-data-resources/blob/718159514c63cfc1ee2d449cd647c9669bb4e390/ember-data-resources/src/-private/resources/query.ts#L15-L17

Therefore the docs need to be adjusted to have the query be positional.

If query is supposed to be a named, let me know and that could be fixed instead.