### PR TITLE
Remove deprecation warning when switching to Ember 6

### DIFF
--- a/ember-data-resources/src/-private/resources/request.ts
+++ b/ember-data-resources/src/-private/resources/request.ts
@@ -2,7 +2,10 @@ import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+
+import * as emberService from '@ember/service';
+const service = emberService.service ?? emberService.inject;
+
 import { waitFor, waitForPromise } from '@ember/test-waiters';
 
 import { Resource } from 'ember-modify-based-class-resource';


### PR DESCRIPTION
This PR removes the following warning when switching to Ember 6.

```
deprecate.js:115 DEPRECATION: Importing `inject` from `@ember/service` is deprecated. Please import `service` instead. [deprecation id: importing-inject-from-ember-service] This will be removed in ember-source 7.0.0. See https://deprecations.emberjs.com/id/importing-inject-from-ember-service for more details.
```